### PR TITLE
Fix deferred length retry behavior for final chunk upload request

### DIFF
--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -868,7 +868,6 @@ export class BaseUpload {
     if (this._uploadLengthDeferred && done) {
       this._size = this._offset + sizeOfValue
       req.setHeader('Upload-Length', `${this._size}`)
-      this._uploadLengthDeferred = false
     }
 
     // The specified uploadSize might not match the actual amount of data that a source


### PR DESCRIPTION
Before this change, if the last chunk upload resulted in a retryable error, the retry will not have the `Upload-Length` header set and the retry will fail. Since there is no need to remove `upload._uploadLengthDeferred` and doing so results in the header not being set on the retry, this PR leaves it set.